### PR TITLE
Fix fcm token and media association

### DIFF
--- a/app/api/tickets/[id]/comments/route.ts
+++ b/app/api/tickets/[id]/comments/route.ts
@@ -116,7 +116,7 @@ export async function POST(
               { 
                 $set: { 
                   'associatedWith.type': 'activity',
-                  'associatedWith.id': activityObjectId
+                  'associatedWith.id': String(activity._id)
                 }
               }
             );

--- a/components/customer/CreateTicketForm.tsx
+++ b/components/customer/CreateTicketForm.tsx
@@ -119,7 +119,7 @@ export function CreateTicketForm() {
   };
 
   const handleMediaUploadComplete = (mediaObj: any) => {
-    setMediaIds(prev => [...prev, mediaObj._id]);
+    setMediaIds(prev => [...prev, mediaObj.id]);
   };
 
   // Always normalize SLA for all request types before rendering

--- a/components/customer/CustomerTicketDetail.tsx
+++ b/components/customer/CustomerTicketDetail.tsx
@@ -123,7 +123,7 @@ export function CustomerTicketDetail({ ticketId }: CustomerTicketDetailProps) {
   };
 
   const handleCommentMediaUploadComplete = (mediaObj: any) => {
-    setCommentMediaIds(prev => [...prev, mediaObj._id]);
+    setCommentMediaIds(prev => [...prev, mediaObj.id]);
   };
 
   // Function to handle media removal from MediaGallery
@@ -422,7 +422,7 @@ export function CustomerTicketDetail({ ticketId }: CustomerTicketDetailProps) {
                 <div className="space-y-2">
                   <label className="font-medium">Attach Media Files</label>
                   <MediaUpload
-                    associatedWith={{ type: 'comment', id: ticketId }}
+                    associatedWith={{ type: 'ticket', id: ticketId }}
                     onUploadComplete={handleCommentMediaUploadComplete}
                     onUploadError={err => toast.error(err || 'Upload failed')}
                     ref={mediaUploadRef}

--- a/components/support/SupportTicketDetail.tsx
+++ b/components/support/SupportTicketDetail.tsx
@@ -166,7 +166,7 @@ export function SupportTicketDetail({ ticketId }: SupportTicketDetailProps) {
   };
 
   const handleCommentMediaUploadComplete = (mediaObj: any) => {
-    setCommentMediaIds(prev => [...prev, mediaObj._id]);
+    setCommentMediaIds(prev => [...prev, mediaObj.id]);
   };
 
   // Function to handle media removal from MediaGallery
@@ -417,7 +417,7 @@ export function SupportTicketDetail({ ticketId }: SupportTicketDetailProps) {
                 <div className="space-y-2">
                   <label className="font-medium">Attach Media Files</label>
                   <MediaUpload
-                    associatedWith={{ type: 'comment', id: ticketId }}
+                    associatedWith={{ type: 'ticket', id: ticketId }}
                     onUploadComplete={handleCommentMediaUploadComplete}
                     onUploadError={err => toast.error(err || 'Upload failed')}
                     ref={mediaUploadRef}

--- a/lib/schemas/fcmToken.schema.ts
+++ b/lib/schemas/fcmToken.schema.ts
@@ -21,8 +21,7 @@ const fcmTokenSchema = new Schema<IFCMToken>({
   userId: {
     type: Schema.Types.ObjectId,
     ref: 'User',
-    required: true,
-    index: true
+    required: true
   },
   token: {
     type: String,
@@ -37,8 +36,7 @@ const fcmTokenSchema = new Schema<IFCMToken>({
   },
   isActive: {
     type: Boolean,
-    default: true,
-    index: true
+    default: true
   },
   lastUsed: {
     type: Date,

--- a/lib/schemas/index.ts
+++ b/lib/schemas/index.ts
@@ -43,7 +43,7 @@ export async function connectToDatabase(): Promise<typeof mongoose> {
 
   if (!cached!.promise) {
     const opts = {
-      bufferCommands: false,
+      bufferCommands: true,
       maxPoolSize: 10,
       serverSelectionTimeoutMS: 5000,
       socketTimeoutMS: 45000,

--- a/test-media-association.js
+++ b/test-media-association.js
@@ -1,0 +1,59 @@
+// Test script to verify media association with activities
+const mongoose = require('mongoose');
+
+// Connect to MongoDB
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/helpdesk', {
+  bufferCommands: true,
+  maxPoolSize: 10,
+  serverSelectionTimeoutMS: 5000,
+  socketTimeoutMS: 45000,
+  family: 4,
+});
+
+// Test media association
+async function testMediaAssociation() {
+  try {
+    console.log('Testing media association...');
+    
+    // Get the Media and TicketActivity models
+    const Media = mongoose.model('Media');
+    const TicketActivity = mongoose.model('TicketActivity');
+    
+    // Find a recent activity with attachments
+    const activity = await TicketActivity.findOne({ 
+      attachments: { $exists: true, $ne: [] } 
+    }).sort({ createdAt: -1 });
+    
+    if (activity) {
+      console.log('Found activity with attachments:', {
+        activityId: activity._id,
+        attachmentsCount: activity.attachments.length,
+        attachments: activity.attachments
+      });
+      
+      // Check if media is properly associated
+      const media = await Media.find({
+        'associatedWith.type': 'activity',
+        'associatedWith.id': String(activity._id)
+      });
+      
+      console.log('Associated media found:', media.length);
+      media.forEach(m => {
+        console.log('- Media:', m.filename, 'ID:', m._id);
+      });
+    } else {
+      console.log('No activities with attachments found');
+    }
+    
+    // Test FCM token schema
+    const FCMToken = mongoose.model('FCMToken');
+    console.log('FCM Token model loaded successfully');
+    
+  } catch (error) {
+    console.error('Test failed:', error);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+testMediaAssociation();


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolves FCM token registration errors, eliminates duplicate schema index warnings, and ensures proper media attachment to activities.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The FCM token registration failed due to Mongoose operations being attempted before connection completion with `bufferCommands: false`. Duplicate schema index warnings were caused by redundant index declarations. Media attachments were not correctly linked to activities because of incorrect ID usage (`_id` vs `id`), initial association type (`comment` vs `ticket`), and improper activity ID conversion during reassociation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4606698a-bf79-42a9-a0e7-5a3856a1aa80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4606698a-bf79-42a9-a0e7-5a3856a1aa80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>